### PR TITLE
adds support for bracketed keys in parameters

### DIFF
--- a/form-urldecoded.js
+++ b/form-urldecoded.js
@@ -1,36 +1,64 @@
-// Filename: form-urldecoded.js  
-// Timestamp: 2017.03.09-11:57:43 (last modified)
-// Author(s): bumblehead <chris@bumblehead.com>  
+// Filename: form-urldecoded.js
+// Timestamp: 2018.08.15-17:52:43 (last modified)
+// Author(s): frabarz <francisco@datawheel.us>
 
-const formurldecoded = module.exports = (uri, ishash) => {
-  let args,
-      uriVals = {};
+/**
+* @param {string} uri The query string to parse. Can be a simple urlencoded string or a full URL.
+* @param {Options} opts Additional options
+* @returns {any}
+*/
+const formurldecoded = (module.exports = (data, opts = {}) => {
+  const ignoreNull = Boolean(opts.ignorenull);
+  const skipIndex = Boolean(opts.skipIndex);
 
-  if (ishash) {
-    uriVals.hash = uri.replace(/[^#]*#?/, '');
-  }
+  const assignValue = (param, value, target) => {
+    const [key, remnant] = parseKey(param);
+    if (remnant !== undefined) {
+      const targetObj = target[key] || defaultTarget(remnant);
+      assignValue(remnant, value, targetObj);
+      target[key] = targetObj;
+    }
+    else if (!Array.isArray(target) || !skipIndex || isNaN(+key) || key !== "") {
+      target[key] = value;
+    }
+    else {
+      target.push(value);
+    }
+    return target;
+  };
 
-  uri = uri.replace(/#.*$/, ''); // remove hash
-  args = uri.replace(/^[^?]*\?/, '');
+  const defaultTarget = key => {
+    const targetKey = key.split("[", 1).shift();
+    return targetKey === "" || !isNaN(+targetKey) ? [] : {};
+  };
+
+  const parseKey = key => {
+    const openIndex = key.indexOf("[");
+    return openIndex > -1
+      ? [key.slice(0, openIndex), key.slice(openIndex + 1).replace("]", "")]
+      : [key];
+  };
+
+  const parseValue = value =>
+    !isNaN(+value)
+      ? +value
+      : /^(true|false)$/.test(value)
+        ? value === "true"
+        : value === "null" || !value ? null : value;
+
+  data = decodeURI(`${data}`.replace(/#.*$/, "")).replace(/\+/g, " ");
+  const indexPercent = data.indexOf("?");
+  const args = indexPercent > -1 ? data.substring(indexPercent + 1) : data;
   
-  if (args && (args = args.split(/&/))) {
-    uriVals = args.reduce((uriVals, argpair) => {
-      let [key, val] = argpair.split(/=/);
-      
-      val = val && decodeURIComponent(val.replace(/\+/g, ''));
+  return args.split("&").reduce((uriVals, param) => {
+    const [key, val] = param.split(/=/);
+    const value = parseValue(val);
+    return value != null || !ignoreNull ? assignValue(key, value, uriVals) : uriVals;
+  }, {});
+});
 
-      if (!isNaN(+val)) {
-        uriVals[key] = +val;
-      } else if (val === 'true') {
-        uriVals[key] = true;
-      } else if (val === 'false') {
-        uriVals[key] = false;                
-      } else {
-        uriVals[key] = val;
-      }
-      
-      return uriVals;
-    }, uriVals);
-  }
-  return uriVals;  
-};
+/**
+* @typedef Options
+* @property {boolean} [ignorenull] Determines if parameters without value should be included in the parsed object. If so, their value will be null.
+* @property {boolean} [skipIndex] Determines if bracketed numbers should be used to set the order of the values in an array.
+*/


### PR DESCRIPTION
This PR enables the library to reverse the result of the `form-urlencoded` library.
It breaks compatibility with the current version, as the second parameter was changed to accept similar options as its encoding counterpart.